### PR TITLE
moving elements speed control

### DIFF
--- a/alien_invasion/main.py
+++ b/alien_invasion/main.py
@@ -9,6 +9,7 @@ from ship import Ship
 from bullet import Bullet
 from alien import Alien
 
+
 class AlienInvasion:
     """общий класс для управления игрой"""
 
@@ -39,7 +40,9 @@ class AlienInvasion:
     def run_game(self):
         """главный игровой цикл"""
 
+        # clock = pygame.time.Clock()  # попытка использовать Clock для решения проблемы с замедлением
         while True:
+            # clock.tick(60)  # попытка использовать Clock для решения проблемы с замедлением
             self._check_events()
 
             if self.stats.game_active:
@@ -93,6 +96,11 @@ class AlienInvasion:
             self.ship.moving_right = True
         elif event.key == pygame.K_LEFT:
             self.ship.moving_left = True
+        elif event.key == pygame.K_UP:
+            self.settings.alien_speed += 0.1
+        elif event.key == pygame.K_DOWN:
+            if self.settings.alien_speed > 0.1:
+                self.settings.alien_speed -= 0.1
         elif event.key == pygame.K_ESCAPE:
             sys.exit()
         elif event.key == pygame.K_SPACE:

--- a/alien_invasion/main.py
+++ b/alien_invasion/main.py
@@ -98,9 +98,14 @@ class AlienInvasion:
             self.ship.moving_left = True
         elif event.key == pygame.K_UP:
             self.settings.alien_speed += 0.1
+            self.settings.bullet_speed += 0.6
+            self.settings.ship_speed += 0.3
         elif event.key == pygame.K_DOWN:
-            if self.settings.alien_speed > 0.1:
+            if self.settings.alien_speed > 0.1 and self.settings.bullet_speed > 0.6\
+                    and self.settings.ship_speed > 0.3:
                 self.settings.alien_speed -= 0.1
+                self.settings.bullet_speed -= 0.6
+                self.settings.ship_speed -= 0.3
         elif event.key == pygame.K_ESCAPE:
             sys.exit()
         elif event.key == pygame.K_SPACE:


### PR DESCRIPTION
Попытался найти информацию про замедление pygame при записи экрана. Не нашёл. Поэкспериментировал с разными fps - не помогло.
Хотел задать 2 режима скоростей: для включённой записи экрана и без записи. Но не ясно, можно ли закодить автоматическое определение наличия или отсутствия запущенной записи экрана на компьютере.

Поэтому предлагаю следующее решение: изменять скорости всех движущихся объектов с помощью кнопок вверх/вниз на клавиатуре. Тогда при замедлении игры при начале записи экрана можно сразу восстановить подвижность несколькими нажатиями клавиши вверх.